### PR TITLE
feat: deploy kube-prometheus-stack + grafana-operator in o11y

### DIFF
--- a/bootstrap/helmfile.d/00-crds.yaml
+++ b/bootstrap/helmfile.d/00-crds.yaml
@@ -20,6 +20,11 @@ releases:
     version: v1.8.2
 
   - name: kube-prometheus-stack
-    namespace: observability
+    namespace: o11y
     chart: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack
     version: 87.10.1
+
+  - name: grafana-operator
+    namespace: o11y
+    chart: oci://ghcr.io/grafana/helm-charts/grafana-operator
+    version: 5.24.0

--- a/kubernetes/apps/o11y/grafana-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/app/helmrelease.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: grafana-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: grafana-operator
+  interval: 1h
+  values:
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/apps/o11y/grafana-operator/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/o11y/grafana-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: grafana-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.24.0
+  url: oci://ghcr.io/grafana/helm-charts/grafana-operator

--- a/kubernetes/apps/o11y/grafana-operator/instance/grafana.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/instance/grafana.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+  labels:
+    dashboards: grafana
+spec:
+  config:
+    analytics:
+      check_for_updates: "false"
+      check_for_plugin_updates: "false"
+      feedback_links_enabled: "false"
+      reporting_enabled: "false"
+    auth:
+      disable_login_form: "false"
+    log:
+      mode: console
+    metrics:
+      enabled: "true"
+    news:
+      news_feed_enabled: "false"
+    plugins:
+      plugin_admin_enabled: "false"
+    server:
+      enable_gzip: "true"
+  deployment:
+    spec:
+      strategy:
+        type: Recreate
+      template:
+        spec:
+          containers:
+            - name: grafana
+              env:
+                - name: GF_SECURITY_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin
+                      key: GF_SECURITY_ADMIN_PASSWORD
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities: { drop: ["ALL"] }
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+          volumes:
+            - name: grafana-data
+              persistentVolumeClaim:
+                claimName: grafana-pvc
+  httpRoute:
+    spec:
+      hostnames:
+        - "grafana.${SECRET_DOMAIN}"
+      parentRefs:
+        - name: envoy-internal
+          namespace: network
+          sectionName: https
+  persistentVolumeClaim:
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+      storageClassName: ceph-rbd
+  disableDefaultSecurityContext: All

--- a/kubernetes/apps/o11y/grafana-operator/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/instance/grafanadatasource.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: prometheus
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasource:
+    type: prometheus
+    name: prometheus
+    access: proxy
+    isDefault: true
+    url: http://prometheus-operated.o11y.svc.cluster.local:9090
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: alertmanager
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasource:
+    type: alertmanager
+    name: alertmanager
+    access: proxy
+    jsonData:
+      implementation: prometheus
+    url: http://alertmanager-operated.o11y.svc.cluster.local:9093

--- a/kubernetes/apps/o11y/grafana-operator/instance/kustomization.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/instance/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./grafana.yaml
+  - ./grafanadatasource.yaml
+  - ./secret.sops.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/o11y/grafana-operator/instance/secret.sops.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/instance/secret.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-admin
+stringData:
+  GF_SECURITY_ADMIN_PASSWORD: ENC[AES256_GCM,data:YdOwwnU8vhgQjE0KgJYbqDxbfaW4wXV1olVd5np/h9c=,iv:XfbpQWNUQPjLvQNJyY6R8mVtGfRYRDjQhmBpfQi1cFc=,tag:U8Ri3IFGo/AAqexWmn2XbQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwdWRvNEY3d0ZaZmh3cWMx
+        NENOdERkenphOFk0eW1PT0tkb21kLy85b1hvCmZSaVhML2ZvMFBpenV3UjlKb0Qw
+        U0FKSC9hSFg4YlNVK1FrdnpWbXRlRU0KLS0tIFNsUEYwUmQ2K1MxNGFudklQV0pV
+        bnR2WG83L1ZSdVoxTG9ac01XRmh4Y2MKngvyLK5fLUAcSeOb22pGjjc82bauKqsy
+        E7z+hPEwXSZE/oktNueod0Jwwr4zDW/CrMF0ADaG4LvzTMEohJRkwg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1hw8r4fnhy55rmvkkrm6lunh5wpmgl6dlam6mhcaxwtm0udvy9u3q78jxgq
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-09T19:43:49Z"
+  mac: ENC[AES256_GCM,data:2AqkAhaCglut++46DXa2KmhcPSw7M2vXbgnTZglxQab/1pGMkF7ApRw5sYGZPoAmrje2ezV47EO2VsWhe2iEArN4B/Rim9u58QgaKrKsoB7bgzyiuIL1277i9R7HjR2HJzkgR3r4ZB+Mn7Av3Em6+yIRofO873/TcbfMOeoRAoo=,iv:mRO1wtrfZzOqQ8PpRz/23hxMEkyjck8PN3M/WX9JYwU=,tag:NBqtdFEcM7TjsD3jnhpZdw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/o11y/grafana-operator/instance/servicemonitor.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/instance/servicemonitor.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: grafana
+spec:
+  endpoints:
+    - port: grafana
+      path: /metrics
+      honorLabels: true
+  jobLabel: grafana
+  namespaceSelector:
+    matchNames:
+      - o11y
+  selector:
+    matchLabels:
+      dashboards: grafana

--- a/kubernetes/apps/o11y/grafana-operator/ks.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/ks.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grafana-operator
+spec:
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: grafana-operator
+      namespace: o11y
+  interval: 1h
+  path: ./kubernetes/apps/o11y/grafana-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: o11y
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grafana-instance
+spec:
+  dependsOn:
+    - name: grafana-operator
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/o11y/grafana-operator/instance
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: o11y
+  wait: false

--- a/kubernetes/apps/o11y/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/app/helmrelease.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: kube-prometheus-stack
+  interval: 1h
+  values:
+    cleanPrometheusOperatorObjectNames: true
+    alertmanager:
+      route:
+        main:
+          enabled: true
+          hostnames:
+            - alertmanager.${SECRET_DOMAIN}
+          parentRefs:
+            - name: envoy-internal
+              namespace: network
+              sectionName: https
+      alertmanagerSpec:
+        externalUrl: https://alertmanager.${SECRET_DOMAIN}
+        storage:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: ceph-rbd
+              resources:
+                requests:
+                  storage: 1Gi
+    kubeEtcd:
+      service:
+        selector:
+          component: kube-apiserver # etcd runs on control plane nodes
+    kubeProxy:
+      enabled: false # Cilium replaces kube-proxy
+    prometheus:
+      route:
+        main:
+          enabled: true
+          hostnames:
+            - prometheus.${SECRET_DOMAIN}
+          parentRefs:
+            - name: envoy-internal
+              namespace: network
+              sectionName: https
+      prometheusSpec:
+        externalUrl: https://prometheus.${SECRET_DOMAIN}
+        podMonitorSelectorNilUsesHelmValues: false
+        probeSelectorNilUsesHelmValues: false
+        ruleSelectorNilUsesHelmValues: false
+        scrapeConfigSelectorNilUsesHelmValues: false
+        serviceMonitorSelectorNilUsesHelmValues: false
+        retention: 30d
+        retentionSize: 45GB
+        resources:
+          requests:
+            cpu: 100m
+          limits:
+            memory: 2000Mi
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: ceph-rbd
+              resources:
+                requests:
+                  storage: 50Gi
+    prometheus-node-exporter:
+      fullnameOverride: node-exporter
+    kube-state-metrics:
+      fullnameOverride: kube-state-metrics
+    grafana:
+      enabled: false
+      forceDeployDashboards: true
+      operator:
+        dashboardsConfigMapRefEnabled: true
+        folder: o11y
+        matchLabels:
+          dashboards: grafana
+    additionalPrometheusRulesMap:
+      oom-rules:
+        groups:
+          - name: oom
+            rules:
+              - alert: OomKilled
+                annotations:
+                  summary: Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} has been OOMKilled {{ $value }} times in the last 10 minutes.
+                expr: (kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 10m >= 1) and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[10m]) == 1
+                labels:
+                  severity: critical

--- a/kubernetes/apps/o11y/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/o11y/kube-prometheus-stack/app/ocirepository.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kube-prometheus-stack
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 87.10.1
+  url: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack

--- a/kubernetes/apps/o11y/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/ks.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kube-prometheus-stack
+spec:
+  dependsOn:
+    - name: grafana-operator # provides the GrafanaDashboard CRD
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: kube-prometheus-stack
+      namespace: o11y
+  interval: 1h
+  path: ./kubernetes/apps/o11y/kube-prometheus-stack/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: o11y
+  wait: false

--- a/kubernetes/apps/o11y/kustomization.yaml
+++ b/kubernetes/apps/o11y/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: o11y
+
+components:
+  - ../../components/sops
+
+resources:
+  - ./namespace.yaml
+  - ./grafana-operator/ks.yaml
+  - ./kube-prometheus-stack/ks.yaml

--- a/kubernetes/apps/o11y/namespace.yaml
+++ b/kubernetes/apps/o11y/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: o11y
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Summary

Adds cluster observability in a new `o11y` namespace, modeled on [onedr0p/home-ops](https://github.com/onedr0p/home-ops/tree/main/kubernetes/apps/o11y).

### kube-prometheus-stack (87.10.1)

- Prometheus: 50Gi `ceph-rbd` PVC, 30d/45GB retention, HTTPRoute at `prometheus.${SECRET_DOMAIN}` on `envoy-internal`
- Alertmanager: 1Gi `ceph-rbd` PVC, HTTPRoute at `alertmanager.${SECRET_DOMAIN}`
- All `*SelectorNilUsesHelmValues: false` so existing ServiceMonitors (cert-manager, rook-ceph, snapshot-controller) are scraped automatically
- Talos-specific: etcd scraped via `component: kube-apiserver` selector (metrics already exposed on `0.0.0.0:2381`), kube-proxy scraping disabled (Cilium)
- In-chart Grafana disabled; dashboards shipped as `GrafanaDashboard` CRs (`forceDeployDashboards` + `dashboardsConfigMapRefEnabled`)
- Generic OOMKilled alert rule

### grafana-operator (5.24.0)

- Operator + `Grafana` instance CR: 5Gi `ceph-rbd` PVC, operator-managed HTTPRoute at `grafana.${SECRET_DOMAIN}`, hardened security context
- Prometheus (default) + Alertmanager datasources
- Admin password in a SOPS-encrypted secret
- ServiceMonitors for both operator and instance

### Ordering / bootstrap

- `kube-prometheus-stack` ks depends on `grafana-operator` (GrafanaDashboard CRD) and `rook-ceph-cluster` (storage); `grafana-instance` depends on the operator and storage
- `bootstrap/helmfile.d/00-crds.yaml`: kube-prometheus-stack CRDs now extract into `o11y`, grafana-operator CRDs added

## Validation

- `kustomize build` + kubeconform pass on all levels (only expected sops-metadata strict-mode warnings)
- Both charts rendered end-to-end with the final values via `helm template`: 27 GrafanaDashboard CRs emitted, no in-chart Grafana workload, HTTPRoutes/etcd service/secret wiring verified
- `component: kube-apiserver` selector verified against the live cluster's apiserver static pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)